### PR TITLE
Add --allocations-csv option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ primary_address,bid_amount_dollars
 ```
 
 ```bash
-solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --bids-csv <BIDS_CSV> <TRANSACTION_LOG> --fee-payer <KEYPAIR>
+solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --input_csv <BIDS_CSV> <TRANSACTION_LOG> --fee-payer <KEYPAIR>
 ```
 
 Example transaction log before:
@@ -31,7 +31,7 @@ Send tokens to the recipients in `<BIDS_CSV>` if the distribution is
 not already recordered in the transaction log.
 
 ```bash
-solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --bids-csv <BIDS_CSV> <TRANSACTION_LOG> --fee-payer <KEYPAIR>
+solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --input_csv <BIDS_CSV> <TRANSACTION_LOG> --fee-payer <KEYPAIR>
 ```
 
 Example output:
@@ -60,7 +60,7 @@ List the differences between a list of expected distributions and the record of 
 transactions have already been sent.
 
 ```bash
-solana-tokens distribute-tokens --dollars-per-sol <NUMBER> --dry-run --bids-csv <BIDS_CSV> <TRANSACTION_LOG>
+solana-tokens distribute-tokens --dollars-per-sol <NUMBER> --dry-run --input_csv <BIDS_CSV> <TRANSACTION_LOG>
 ```
 
 Example bids.csv:

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -42,12 +42,17 @@ where
                         .help("Transactions database file"),
                 )
                 .arg(
-                    Arg::with_name("bids_csv")
-                        .long("bids-csv")
+                    Arg::with_name("allocations_csv")
+                        .long("allocations-csv")
+                        .help("Input CSV contains token allocations, not bids"),
+                )
+                .arg(
+                    Arg::with_name("input_csv")
+                        .long("input_csv")
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
-                        .help("Bids CSV file"),
+                        .help("Input CSV file"),
                 )
                 .arg(
                     Arg::with_name("dollars_per_sol")
@@ -55,7 +60,8 @@ where
                         .required(true)
                         .takes_value(true)
                         .value_name("NUMBER")
-                        .help("Dollars per SOL"),
+                        .help("Dollars per SOL, if input CSV contains bids")
+                        .conflicts_with("allocations_csv")
                 )
                 .arg(
                     Arg::with_name("dry_run")
@@ -141,8 +147,8 @@ where
             SubCommand::with_name("balances")
                 .about("Balance of each account")
                 .arg(
-                    Arg::with_name("bids_csv")
-                        .long("bids-csv")
+                    Arg::with_name("input_csv")
+                        .long("input_csv")
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
@@ -162,9 +168,10 @@ where
 
 fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs<String> {
     DistributeTokensArgs {
-        bids_csv: value_t_or_exit!(matches, "bids_csv", String),
+        input_csv: value_t_or_exit!(matches, "input_csv", String),
+        allocations_csv: matches.is_present("allocations_csv"),
         transactions_db: value_t_or_exit!(matches, "transactions_db", String),
-        dollars_per_sol: value_t_or_exit!(matches, "dollars_per_sol", f64),
+        dollars_per_sol: value_t!(matches, "dollars_per_sol", f64).ok(),
         dry_run: matches.is_present("dry_run"),
         sender_keypair: value_t!(matches, "sender_keypair", String).ok(),
         fee_payer: value_t!(matches, "fee_payer", String).ok(),
@@ -185,7 +192,7 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeStakeArgs<
 
 fn parse_balances_args(matches: &ArgMatches<'_>) -> BalancesArgs {
     BalancesArgs {
-        bids_csv: value_t_or_exit!(matches, "bids_csv", String),
+        input_csv: value_t_or_exit!(matches, "input_csv", String),
         dollars_per_sol: value_t_or_exit!(matches, "dollars_per_sol", f64),
     }
 }

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -42,21 +42,17 @@ where
                         .help("Transactions database file"),
                 )
                 .arg(
-                    Arg::with_name("allocations_csv")
-                        .long("allocations-csv")
-                        .required(true)
-                        .takes_value(true)
-                        .value_name("FILE")
-                        .help("Allocations CSV file")
-                        .conflicts_with("bids_csv"),
+                    Arg::with_name("from_bids")
+                        .long("from-bids")
+                        .help("Input CSV contains bids in dollars, not allocations in SOL"),
                 )
                 .arg(
-                    Arg::with_name("bids_csv")
-                        .long("bids-csv")
+                    Arg::with_name("input_csv")
+                        .long("input_csv")
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
-                        .help("Bids CSV file"),
+                        .help("Input CSV file"),
                 )
                 .arg(
                     Arg::with_name("dollars_per_sol")
@@ -64,8 +60,7 @@ where
                         .required(true)
                         .takes_value(true)
                         .value_name("NUMBER")
-                        .help("For converting bids to SOL, \
-                        or displaying total fiat in allocations ")
+                        .help("Dollars per SOL, if input CSV contains bids")
                 )
                 .arg(
                     Arg::with_name("dry_run")
@@ -151,8 +146,8 @@ where
             SubCommand::with_name("balances")
                 .about("Balance of each account")
                 .arg(
-                    Arg::with_name("bids_csv")
-                        .long("bids-csv")
+                    Arg::with_name("input_csv")
+                        .long("input_csv")
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
@@ -172,8 +167,8 @@ where
 
 fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs<String> {
     DistributeTokensArgs {
-        bids_csv: value_t!(matches, "bids_csv", String).ok(),
-        allocations_csv: value_t!(matches, "allocations_csv", String).ok(),
+        input_csv: value_t_or_exit!(matches, "input_csv", String),
+        from_bids: matches.is_present("from_bids"),
         transactions_db: value_t_or_exit!(matches, "transactions_db", String),
         dollars_per_sol: value_t!(matches, "dollars_per_sol", f64).ok(),
         dry_run: matches.is_present("dry_run"),
@@ -196,7 +191,7 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeStakeArgs<
 
 fn parse_balances_args(matches: &ArgMatches<'_>) -> BalancesArgs {
     BalancesArgs {
-        bids_csv: value_t_or_exit!(matches, "bids_csv", String),
+        input_csv: value_t_or_exit!(matches, "input_csv", String),
         dollars_per_sol: value_t_or_exit!(matches, "dollars_per_sol", f64),
     }
 }

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -44,15 +44,19 @@ where
                 .arg(
                     Arg::with_name("allocations_csv")
                         .long("allocations-csv")
-                        .help("Input CSV contains token allocations, not bids"),
-                )
-                .arg(
-                    Arg::with_name("input_csv")
-                        .long("input_csv")
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
-                        .help("Input CSV file"),
+                        .help("Allocations CSV file")
+                        .conflicts_with("bids_csv"),
+                )
+                .arg(
+                    Arg::with_name("bids_csv")
+                        .long("bids-csv")
+                        .required(true)
+                        .takes_value(true)
+                        .value_name("FILE")
+                        .help("Bids CSV file"),
                 )
                 .arg(
                     Arg::with_name("dollars_per_sol")
@@ -60,8 +64,8 @@ where
                         .required(true)
                         .takes_value(true)
                         .value_name("NUMBER")
-                        .help("Dollars per SOL, if input CSV contains bids")
-                        .conflicts_with("allocations_csv")
+                        .help("For converting bids to SOL, \
+                        or displaying total fiat in allocations ")
                 )
                 .arg(
                     Arg::with_name("dry_run")
@@ -147,8 +151,8 @@ where
             SubCommand::with_name("balances")
                 .about("Balance of each account")
                 .arg(
-                    Arg::with_name("input_csv")
-                        .long("input_csv")
+                    Arg::with_name("bids_csv")
+                        .long("bids-csv")
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
@@ -168,8 +172,8 @@ where
 
 fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs<String> {
     DistributeTokensArgs {
-        input_csv: value_t_or_exit!(matches, "input_csv", String),
-        allocations_csv: matches.is_present("allocations_csv"),
+        bids_csv: value_t!(matches, "bids_csv", String).ok(),
+        allocations_csv: value_t!(matches, "allocations_csv", String).ok(),
         transactions_db: value_t_or_exit!(matches, "transactions_db", String),
         dollars_per_sol: value_t!(matches, "dollars_per_sol", f64).ok(),
         dry_run: matches.is_present("dry_run"),
@@ -192,7 +196,7 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeStakeArgs<
 
 fn parse_balances_args(matches: &ArgMatches<'_>) -> BalancesArgs {
     BalancesArgs {
-        input_csv: value_t_or_exit!(matches, "input_csv", String),
+        bids_csv: value_t_or_exit!(matches, "bids_csv", String),
         dollars_per_sol: value_t_or_exit!(matches, "dollars_per_sol", f64),
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -5,9 +5,10 @@ use solana_sdk::{pubkey::Pubkey, signature::Signer};
 use std::error::Error;
 
 pub struct DistributeTokensArgs<K> {
-    pub bids_csv: String,
+    pub input_csv: String,
+    pub allocations_csv: bool,
     pub transactions_db: String,
-    pub dollars_per_sol: f64,
+    pub dollars_per_sol: Option<f64>,
     pub dry_run: bool,
     pub sender_keypair: Option<K>,
     pub fee_payer: Option<K>,
@@ -24,7 +25,7 @@ pub struct DistributeStakeArgs<P, K> {
 }
 
 pub struct BalancesArgs {
-    pub bids_csv: String,
+    pub input_csv: String,
     pub dollars_per_sol: f64,
 }
 
@@ -48,7 +49,8 @@ pub fn resolve_command(
             let mut wallet_manager = maybe_wallet_manager()?;
             let matches = ArgMatches::default();
             let resolved_args = DistributeTokensArgs {
-                bids_csv: args.bids_csv,
+                input_csv: args.input_csv,
+                allocations_csv: args.allocations_csv,
                 transactions_db: args.transactions_db,
                 dollars_per_sol: args.dollars_per_sol,
                 dry_run: args.dry_run,

--- a/src/args.rs
+++ b/src/args.rs
@@ -5,8 +5,8 @@ use solana_sdk::{pubkey::Pubkey, signature::Signer};
 use std::error::Error;
 
 pub struct DistributeTokensArgs<K> {
-    pub bids_csv: Option<String>,
-    pub allocations_csv: Option<String>,
+    pub input_csv: String,
+    pub from_bids: bool,
     pub transactions_db: String,
     pub dollars_per_sol: Option<f64>,
     pub dry_run: bool,
@@ -25,7 +25,7 @@ pub struct DistributeStakeArgs<P, K> {
 }
 
 pub struct BalancesArgs {
-    pub bids_csv: String,
+    pub input_csv: String,
     pub dollars_per_sol: f64,
 }
 
@@ -49,8 +49,8 @@ pub fn resolve_command(
             let mut wallet_manager = maybe_wallet_manager()?;
             let matches = ArgMatches::default();
             let resolved_args = DistributeTokensArgs {
-                bids_csv: args.bids_csv,
-                allocations_csv: args.allocations_csv,
+                input_csv: args.input_csv,
+                from_bids: args.from_bids,
                 transactions_db: args.transactions_db,
                 dollars_per_sol: args.dollars_per_sol,
                 dry_run: args.dry_run,

--- a/src/args.rs
+++ b/src/args.rs
@@ -5,8 +5,8 @@ use solana_sdk::{pubkey::Pubkey, signature::Signer};
 use std::error::Error;
 
 pub struct DistributeTokensArgs<K> {
-    pub input_csv: String,
-    pub allocations_csv: bool,
+    pub bids_csv: Option<String>,
+    pub allocations_csv: Option<String>,
     pub transactions_db: String,
     pub dollars_per_sol: Option<f64>,
     pub dry_run: bool,
@@ -25,7 +25,7 @@ pub struct DistributeStakeArgs<P, K> {
 }
 
 pub struct BalancesArgs {
-    pub input_csv: String,
+    pub bids_csv: String,
     pub dollars_per_sol: f64,
 }
 
@@ -49,7 +49,7 @@ pub fn resolve_command(
             let mut wallet_manager = maybe_wallet_manager()?;
             let matches = ArgMatches::default();
             let resolved_args = DistributeTokensArgs {
-                input_csv: args.input_csv,
+                bids_csv: args.bids_csv,
                 allocations_csv: args.allocations_csv,
                 transactions_db: args.transactions_db,
                 dollars_per_sol: args.dollars_per_sol,

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -276,29 +276,17 @@ pub fn process_distribute_tokens<T: Client>(
     client: &ThinClient<T>,
     args: &DistributeTokensArgs<Box<dyn Signer>>,
 ) -> Result<(), Error> {
-    let input_csv = if let Some(i) = &args.allocations_csv {
-        i
-    } else {
-        let Some(i) = &args.bids_csv;
-        i
-    };
-    let mut allocations: Vec<Allocation> = if let Some(_) = &args.allocations_csv {
-        let mut rdr = ReaderBuilder::new()
-            .trim(Trim::All)
-            .from_path(input_csv)?;
-            rdr.deserialize().map(|entry| entry.unwrap()).collect()
-        } else {
-        let mut rdr = ReaderBuilder::new()
-            .trim(Trim::All)
-            .from_path(input_csv)?;
-        let bids: Vec<Bid> = rdr
-            .deserialize()
-            .map(|bid| bid.unwrap())
-            .collect();
+    let mut rdr = ReaderBuilder::new()
+        .trim(Trim::All)
+        .from_path(&args.input_csv)?;
+    let mut allocations: Vec<Allocation> = if args.from_bids {
+        let bids: Vec<Bid> = rdr.deserialize().map(|bid| bid.unwrap()).collect();
         bids
             .into_iter()
             .map(|bid| create_allocation(&bid, args.dollars_per_sol.unwrap()))
             .collect()
+    } else {
+        rdr.deserialize().map(|entry| entry.unwrap()).collect()
     };
 
     let starting_total_tokens: f64 = allocations.iter().map(|x| x.amount).sum();
@@ -431,7 +419,7 @@ pub fn process_balances<T: Client>(
 ) -> Result<(), csv::Error> {
     let mut rdr = ReaderBuilder::new()
         .trim(Trim::All)
-        .from_path(&args.bids_csv)?;
+        .from_path(&args.input_csv)?;
     let bids: Vec<Bid> = rdr.deserialize().map(|bid| bid.unwrap()).collect();
     let allocations: Vec<Allocation> = bids
         .into_iter()
@@ -479,7 +467,7 @@ pub fn test_process_distribute_bids_with_client<C: Client>(client: C, sender_key
         accepted_amount_dollars: 1000.0,
     };
     let bids_file = NamedTempFile::new().unwrap();
-    let bids_csv = bids_file.path().to_str().unwrap().to_string();
+    let input_csv = bids_file.path().to_str().unwrap().to_string();
     let mut wtr = csv::WriterBuilder::new().from_writer(bids_file);
     wtr.serialize(&bid).unwrap();
     wtr.flush().unwrap();
@@ -496,8 +484,8 @@ pub fn test_process_distribute_bids_with_client<C: Client>(client: C, sender_key
         sender_keypair: Some(Box::new(sender_keypair)),
         fee_payer: Some(Box::new(fee_payer)),
         dry_run: false,
-        allocations_csv: None,
-        bids_csv: Some(bids_csv),
+        from_bids: true,
+        input_csv,
         transactions_db: transactions_db.clone(),
         dollars_per_sol: Some(0.22),
     };
@@ -540,7 +528,7 @@ pub fn test_process_distribute_allocations_with_client<C: Client>(client: C, sen
         amount: 1000.0,
     };
     let allocations_file = NamedTempFile::new().unwrap();
-    let allocations_csv = allocations_file.path().to_str().unwrap().to_string();
+    let input_csv = allocations_file.path().to_str().unwrap().to_string();
     let mut wtr = csv::WriterBuilder::new().from_writer(allocations_file);
     wtr.serialize(&allocation).unwrap();
     wtr.flush().unwrap();
@@ -557,8 +545,8 @@ pub fn test_process_distribute_allocations_with_client<C: Client>(client: C, sen
         sender_keypair: Some(Box::new(sender_keypair)),
         fee_payer: Some(Box::new(fee_payer)),
         dry_run: false,
-        allocations_csv: Some(allocations_csv),
-        bids_csv: None,
+        input_csv,
+        from_bids: false,
         transactions_db: transactions_db.clone(),
         dollars_per_sol: None,
     };

--- a/tests/tokens.rs
+++ b/tests/tokens.rs
@@ -1,7 +1,7 @@
 use solana_client::rpc_client::RpcClient;
 use solana_core::validator::{TestValidator, TestValidatorOptions};
 use solana_sdk::native_token::sol_to_lamports;
-use solana_tokens::tokens::test_process_distribute_with_client;
+use solana_tokens::tokens::test_process_distribute_bids_with_client;
 use std::fs::remove_dir_all;
 
 #[test]
@@ -12,7 +12,7 @@ fn test_process_distribute_with_rpc_client() {
         ..TestValidatorOptions::default()
     });
     let rpc_client = RpcClient::new_socket(validator.leader_data.rpc);
-    test_process_distribute_with_client(rpc_client, validator.alice);
+    test_process_distribute_bids_with_client(rpc_client, validator.alice);
 
     validator.server.close().unwrap();
     remove_dir_all(validator.ledger_path).unwrap();


### PR DESCRIPTION
Add `--allocations-csv` flag, which is mutually exclusive with `--dollars-per-sol`.  Setting the flag indicates the csv entries are given in SOL, not dollars.

Fixes #12 