### PR TITLE
Add --no-wait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,6 +3455,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-stake-program",
+ "solana-transaction-status",
  "tempfile",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ solana-remote-wallet = "1.1.8"
 solana-runtime = "1.1.8"
 solana-sdk = "1.1.8"
 solana-stake-program = "1.1.8"
+solana-transaction-status = "1.1.8"
 tempfile = "3.1.0"
 thiserror = "1.0"
 

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -68,6 +68,11 @@ where
                         .help("Do not execute any transfers"),
                 )
                 .arg(
+                    Arg::with_name("no_wait")
+                        .long("no-wait")
+                        .help("Don't wait for transaction confirmations"),
+                )
+                .arg(
                     Arg::with_name("sender_keypair")
                         .long("from")
                         .takes_value(true)
@@ -107,6 +112,11 @@ where
                     Arg::with_name("dry_run")
                         .long("dry-run")
                         .help("Do not execute any transfers"),
+                )
+                .arg(
+                    Arg::with_name("no_wait")
+                        .long("no-wait")
+                        .help("Don't wait for transaction confirmations"),
                 )
                 .arg(
                     Arg::with_name("stake_account_address")
@@ -184,6 +194,7 @@ fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArg
         transactions_db: value_t_or_exit!(matches, "transactions_db", String),
         dollars_per_sol: value_t!(matches, "dollars_per_sol", f64).ok(),
         dry_run: matches.is_present("dry_run"),
+        no_wait: matches.is_present("no_wait"),
         sender_keypair: value_t!(matches, "sender_keypair", String).ok(),
         fee_payer: value_t!(matches, "fee_payer", String).ok(),
     }
@@ -194,6 +205,7 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeStakeArgs<
         allocations_csv: value_t_or_exit!(matches, "allocations_csv", String),
         transactions_db: value_t_or_exit!(matches, "transactions_db", String),
         dry_run: matches.is_present("dry_run"),
+        no_wait: matches.is_present("no_wait"),
         stake_account_address: value_t_or_exit!(matches, "stake_account_address", String),
         sol_for_fees: value_t_or_exit!(matches, "sol_for_fees", f64),
         stake_authority: value_t!(matches, "stake_authority", String).ok(),

--- a/src/args.rs
+++ b/src/args.rs
@@ -10,6 +10,7 @@ pub struct DistributeTokensArgs<K> {
     pub transactions_db: String,
     pub dollars_per_sol: Option<f64>,
     pub dry_run: bool,
+    pub no_wait: bool,
     pub sender_keypair: Option<K>,
     pub fee_payer: Option<K>,
 }
@@ -18,6 +19,7 @@ pub struct DistributeStakeArgs<P, K> {
     pub allocations_csv: String,
     pub transactions_db: String,
     pub dry_run: bool,
+    pub no_wait: bool,
     pub sol_for_fees: f64,
     pub stake_account_address: P,
     pub stake_authority: Option<K>,
@@ -56,6 +58,7 @@ pub fn resolve_command(
                 transactions_db: args.transactions_db,
                 dollars_per_sol: args.dollars_per_sol,
                 dry_run: args.dry_run,
+                no_wait: args.no_wait,
                 sender_keypair: args.sender_keypair.as_ref().map(|key_url| {
                     signer_from_path(&matches, &key_url, "sender", &mut wallet_manager).unwrap()
                 }),
@@ -72,6 +75,7 @@ pub fn resolve_command(
                 allocations_csv: args.allocations_csv,
                 transactions_db: args.transactions_db,
                 dry_run: args.dry_run,
+                no_wait: args.no_wait,
                 stake_account_address: pubkey_from_path(
                     &matches,
                     &args.stake_account_address,

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -127,12 +127,16 @@ fn distribute_tokens<T: Client>(
             let transaction = Transaction::new(&signers, message, blockhash);
             let signature = transaction.signatures[0];
             set_transaction_info(db, &allocation, &signature, None, false)?;
-            client.send_transaction(transaction)
+            if args.no_wait {
+                client.async_send_transaction(transaction)
+            } else {
+                client.send_transaction(transaction)
+            }
         };
         match result {
             Ok(signature) => {
                 println!("Finalized transaction with signature {}", signature);
-                if !args.dry_run {
+                if !args.dry_run && !args.no_wait {
                     set_transaction_info(db, &allocation, &signature, None, true)?;
                 }
             }
@@ -215,12 +219,16 @@ fn distribute_stake<T: Client>(
                 Some(&new_stake_account_address),
                 false,
             )?;
-            client.send_transaction(transaction)
+            if args.no_wait {
+                client.async_send_transaction(transaction)
+            } else {
+                client.send_transaction(transaction)
+            }
         };
         match result {
             Ok(signature) => {
                 println!("Finalized transaction with signature {}", signature);
-                if !args.dry_run {
+                if !args.dry_run && !args.no_wait {
                     set_transaction_info(
                         db,
                         &allocation,
@@ -487,6 +495,7 @@ pub fn test_process_distribute_bids_with_client<C: Client>(client: C, sender_key
         sender_keypair: Some(Box::new(sender_keypair)),
         fee_payer: Some(Box::new(fee_payer)),
         dry_run: false,
+        no_wait: false,
         from_bids: true,
         input_csv,
         transactions_db: transactions_db.clone(),
@@ -551,6 +560,7 @@ pub fn test_process_distribute_allocations_with_client<C: Client>(
         sender_keypair: Some(Box::new(sender_keypair)),
         fee_payer: Some(Box::new(fee_payer)),
         dry_run: false,
+        no_wait: false,
         input_csv,
         from_bids: false,
         transactions_db: transactions_db.clone(),
@@ -636,6 +646,7 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
         withdraw_authority: Some(Box::new(withdraw_authority)),
         fee_payer: Some(Box::new(fee_payer)),
         dry_run: false,
+        no_wait: false,
         sol_for_fees: 1.0,
         allocations_csv,
         transactions_db: transactions_db.clone(),

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -123,7 +123,7 @@ fn distribute_tokens<T: Client>(
             let lamports = sol_to_lamports(allocation.amount);
             let instruction = system_instruction::transfer(&from, &to, lamports);
             let message = Message::new_with_payer(&[instruction], Some(&fee_payer_pubkey));
-            let (blockhash, _fee_caluclator) = client.get_recent_blockhash_and_fees()?;
+            let (blockhash, _fee_caluclator) = client.get_recent_blockhash()?;
             let transaction = Transaction::new(&signers, message, blockhash);
             let signature = transaction.signatures[0];
             set_transaction_info(db, &allocation, &signature, None, false)?;
@@ -205,7 +205,7 @@ fn distribute_stake<T: Client>(
             ));
 
             let message = Message::new_with_payer(&instructions, Some(&fee_payer_pubkey));
-            let (blockhash, _fee_caluclator) = client.get_recent_blockhash_and_fees()?;
+            let (blockhash, _fee_caluclator) = client.get_recent_blockhash()?;
             let transaction = Transaction::new(&signers, message, blockhash);
             let signature = transaction.signatures[0];
             set_transaction_info(

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -804,7 +804,7 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
 mod tests {
     use super::*;
     use solana_runtime::{bank::Bank, bank_client::BankClient};
-    use solana_sdk::{transaction::TransactionError, genesis_config::create_genesis_config};
+    use solana_sdk::{genesis_config::create_genesis_config, transaction::TransactionError};
 
     #[test]
     fn test_process_distribute_bids() {
@@ -859,40 +859,68 @@ mod tests {
     #[test]
     fn test_update_finalized_transaction_not_landed() {
         // Keep waiting for a transaction that hasn't landed yet.
-        let mut db = PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
+        let mut db =
+            PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
         let signature = Signature::default();
         let transaction_info = TransactionInfo::default();
         db.set(&signature.to_string(), &transaction_info).unwrap();
-        assert_eq!(update_finalized_transaction(&mut db, &signature, None).unwrap(), true);
+        assert_eq!(
+            update_finalized_transaction(&mut db, &signature, None).unwrap(),
+            true
+        );
 
         // Unchanged
-        assert_eq!(db.get::<TransactionInfo>(&signature.to_string()).unwrap(), transaction_info);
+        assert_eq!(
+            db.get::<TransactionInfo>(&signature.to_string()).unwrap(),
+            transaction_info
+        );
     }
 
     #[test]
     fn test_update_finalized_transaction_confirming() {
         // Keep waiting for a transaction that is still being confirmed.
-        let mut db = PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
+        let mut db =
+            PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
         let signature = Signature::default();
         let transaction_info = TransactionInfo::default();
         db.set(&signature.to_string(), &transaction_info).unwrap();
-        let transaction_status = TransactionStatus { slot: 0, confirmations: Some(1), status: Ok(()), err: None};
-        assert_eq!(update_finalized_transaction(&mut db, &signature, Some(transaction_status)).unwrap(), true);
+        let transaction_status = TransactionStatus {
+            slot: 0,
+            confirmations: Some(1),
+            status: Ok(()),
+            err: None,
+        };
+        assert_eq!(
+            update_finalized_transaction(&mut db, &signature, Some(transaction_status)).unwrap(),
+            true
+        );
 
         // Unchanged
-        assert_eq!(db.get::<TransactionInfo>(&signature.to_string()).unwrap(), transaction_info);
+        assert_eq!(
+            db.get::<TransactionInfo>(&signature.to_string()).unwrap(),
+            transaction_info
+        );
     }
 
     #[test]
     fn test_update_finalized_transaction_failed() {
         // Don't wait if the transaction failed to execute.
-        let mut db = PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
+        let mut db =
+            PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
         let signature = Signature::default();
         let transaction_info = TransactionInfo::default();
         db.set(&signature.to_string(), &transaction_info).unwrap();
         let status = Err(TransactionError::AccountNotFound);
-        let transaction_status = TransactionStatus { slot: 0, confirmations: None, status, err: None};
-        assert_eq!(update_finalized_transaction(&mut db, &signature, Some(transaction_status)).unwrap(), false);
+        let transaction_status = TransactionStatus {
+            slot: 0,
+            confirmations: None,
+            status,
+            err: None,
+        };
+        assert_eq!(
+            update_finalized_transaction(&mut db, &signature, Some(transaction_status)).unwrap(),
+            false
+        );
 
         // Ensure TransactionInfo has been purged.
         assert_eq!(db.get::<TransactionInfo>(&signature.to_string()), None);
@@ -901,14 +929,26 @@ mod tests {
     #[test]
     fn test_update_finalized_transaction_finalized() {
         // Don't wait once the transaction has been finalized.
-        let mut db = PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
+        let mut db =
+            PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
         let signature = Signature::default();
         let mut transaction_info = TransactionInfo::default();
         db.set(&signature.to_string(), &transaction_info).unwrap();
-        let transaction_status = TransactionStatus { slot: 0, confirmations: None, status: Ok(()), err: None};
-        assert_eq!(update_finalized_transaction(&mut db, &signature, Some(transaction_status)).unwrap(), false);
+        let transaction_status = TransactionStatus {
+            slot: 0,
+            confirmations: None,
+            status: Ok(()),
+            err: None,
+        };
+        assert_eq!(
+            update_finalized_transaction(&mut db, &signature, Some(transaction_status)).unwrap(),
+            false
+        );
 
         transaction_info.finalized = true;
-        assert_eq!(db.get::<TransactionInfo>(&signature.to_string()).unwrap(), transaction_info);
+        assert_eq!(
+            db.get::<TransactionInfo>(&signature.to_string()).unwrap(),
+            transaction_info
+        );
     }
 }


### PR DESCRIPTION
#### Problem

The application may terminate before all transactions are finalized. The current implementation conservatively panics if it detects a transaction in the database that hasn't been finalized.

#### Proposed changes

Check the status of unfinalized transactions on startup.

Fixes #10, #6 