### PR TITLE
Continue when transactions not yet finalized

### DIFF
--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -70,9 +70,6 @@ fn apply_previous_transactions(
     transaction_infos: &[TransactionInfo],
 ) {
     for transaction_info in transaction_infos {
-        if !transaction_info.finalized {
-            panic!("Attempt to apply an unconfirmed transaction. Please confirm the trarnsaction has been finalized or that its blockhash has expired.");
-        }
         let mut amount = transaction_info.amount;
         for allocation in allocations.iter_mut() {
             if allocation.recipient != transaction_info.recipient {
@@ -339,8 +336,7 @@ pub fn process_distribute_tokens<T: Client>(
     let mut db = open_db(&args.transactions_db, args.dry_run)?;
     let still_finalizing = update_finalized_transactions(client, &mut db)?;
     if still_finalizing {
-        eprintln!("Still finalizing transactions. Try again in 10 seconds");
-        process::exit(1);
+        eprintln!("warning: some transactions not yet finalized");
     }
 
     let transaction_infos = read_transaction_infos(&db);
@@ -507,8 +503,7 @@ pub fn process_distribute_stake<T: Client>(
     let mut db = open_db(&args.transactions_db, args.dry_run)?;
     let still_finalizing = update_finalized_transactions(client, &mut db)?;
     if still_finalizing {
-        eprintln!("Still finalizing transactions. Try again in 10 seconds");
-        process::exit(1);
+        eprintln!("warning: some transactions not yet finalized");
     }
 
     let mut allocations = merge_allocations(&allocations);


### PR DESCRIPTION
If those transactions are dropped, the next run will execute them.