### PR TITLE
Add a CSV printer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,83 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'solana-tokens'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=solana-tokens"
+                ],
+                "filter": {
+                    "name": "solana-tokens",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'solana-tokens'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=solana-tokens",
+                    "--package=solana-tokens"
+                ],
+                "filter": {
+                    "name": "solana-tokens",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'solana-tokens'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=solana-tokens",
+                    "--package=solana-tokens"
+                ],
+                "filter": {
+                    "name": "solana-tokens",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'tokens'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=tokens",
+                    "--package=solana-tokens"
+                ],
+                "filter": {
+                    "name": "tokens",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -1,4 +1,6 @@
-use crate::args::{Args, BalancesArgs, Command, DistributeStakeArgs, DistributeTokensArgs};
+use crate::args::{
+    Args, BalancesArgs, Command, DistributeStakeArgs, DistributeTokensArgs, PrintDbArgs,
+};
 use clap::{value_t, value_t_or_exit, App, Arg, ArgMatches, SubCommand};
 use solana_clap_utils::input_validators::{is_valid_pubkey, is_valid_signer};
 use solana_cli_config::CONFIG_FILE;
@@ -189,6 +191,26 @@ where
                         .help("Dollars per SOL"),
                 ),
         )
+        .subcommand(
+            SubCommand::with_name("print-database")
+                .about("Print the database to a CSV file")
+                .arg(
+                    Arg::with_name("transactions_db")
+                        .required(true)
+                        .index(1)
+                        .takes_value(true)
+                        .value_name("FILE")
+                        .help("Transactions database file"),
+                )
+                .arg(
+                    Arg::with_name("output_path")
+                        .long("output-path")
+                        .required(true)
+                        .takes_value(true)
+                        .value_name("FILE")
+                        .help("Output file"),
+                ),
+        )
         .get_matches_from(args)
 }
 
@@ -228,6 +250,13 @@ fn parse_balances_args(matches: &ArgMatches<'_>) -> BalancesArgs {
     }
 }
 
+fn parse_print_db_args(matches: &ArgMatches<'_>) -> PrintDbArgs {
+    PrintDbArgs {
+        transactions_db: value_t_or_exit!(matches, "transactions_db", String),
+        output_path: value_t_or_exit!(matches, "output_path", String),
+    }
+}
+
 pub fn parse_args<I, T>(args: I) -> Args<String, String>
 where
     I: IntoIterator<Item = T>,
@@ -245,6 +274,7 @@ where
             Command::DistributeStake(parse_distribute_stake_args(matches))
         }
         ("balances", Some(matches)) => Command::Balances(parse_balances_args(matches)),
+        ("print-database", Some(matches)) => Command::PrintDb(parse_print_db_args(matches)),
         _ => {
             eprintln!("{}", matches.usage());
             exit(1);

--- a/src/args.rs
+++ b/src/args.rs
@@ -34,10 +34,16 @@ pub struct BalancesArgs {
     pub dollars_per_sol: Option<f64>,
 }
 
+pub struct PrintDbArgs {
+    pub transactions_db: String,
+    pub output_path: String,
+}
+
 pub enum Command<P, K> {
     DistributeTokens(DistributeTokensArgs<K>),
     DistributeStake(DistributeStakeArgs<P, K>),
     Balances(BalancesArgs),
+    PrintDb(PrintDbArgs),
 }
 
 pub struct Args<P, K> {
@@ -106,5 +112,6 @@ pub fn resolve_command(
             Ok(Command::DistributeStake(resolved_args))
         }
         Command::Balances(args) => Ok(Command::Balances(args)),
+        Command::PrintDb(args) => Ok(Command::PrintDb(args)),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         Command::Balances(args) => {
             tokens::process_balances(&thin_client, &args)?;
         }
+        Command::PrintDb(args) => {
+            tokens::process_print_db(&args)?;
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
#### Problem

The PickleDb YAML database isn't very readable because it serializes values and then serializes the key-value pairs.

#### Proposed changes

Add new command `print-database`, which creates a CSV file that's nearly identical to the database file created before the migration to PickleDb.

Fixes #11 