### PR TITLE
Remove all the copypasta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,6 +3445,7 @@ dependencies = [
  "console 0.10.3",
  "csv",
  "indexmap",
+ "itertools 0.9.0",
  "pickledb",
  "serde",
  "solana-clap-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ csv = "1.1.3"
 clap = "2.33.0"
 console = "0.10.3"
 indexmap = "1.3.2"
+itertools = "0.9.0"
 pickledb = "0.4.1"
 serde = { version = "1.0", features = ["derive"] }
 solana-clap-utils = "1.1.8"

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -108,8 +108,8 @@ where
                         .help("Transactions database file"),
                 )
                 .arg(
-                    Arg::with_name("allocations_csv")
-                        .long("allocations-csv")
+                    Arg::with_name("input_csv")
+                        .long("input-csv")
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
@@ -231,7 +231,7 @@ fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArg
 
 fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeStakeArgs<String, String> {
     DistributeStakeArgs {
-        allocations_csv: value_t_or_exit!(matches, "allocations_csv", String),
+        input_csv: value_t_or_exit!(matches, "input_csv", String),
         transactions_db: value_t_or_exit!(matches, "transactions_db", String),
         dry_run: matches.is_present("dry_run"),
         no_wait: matches.is_present("no_wait"),

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -229,8 +229,8 @@ fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArg
     }
 }
 
-fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeStakeArgs<String, String> {
-    DistributeStakeArgs {
+fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs<String, String> {
+    let stake_args = DistributeStakeArgs {
         input_csv: value_t_or_exit!(matches, "input_csv", String),
         transactions_db: value_t_or_exit!(matches, "transactions_db", String),
         dry_run: matches.is_present("dry_run"),
@@ -240,6 +240,18 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeStakeArgs<
         stake_authority: value_t!(matches, "stake_authority", String).ok(),
         withdraw_authority: value_t!(matches, "withdraw_authority", String).ok(),
         fee_payer: value_t!(matches, "fee_payer", String).ok(),
+    };
+    DistributeTokensArgs {
+        input_csv: value_t_or_exit!(matches, "input_csv", String),
+        from_bids: false,
+        transactions_db: value_t_or_exit!(matches, "transactions_db", String),
+        dollars_per_sol: None,
+        dry_run: matches.is_present("dry_run"),
+        no_wait: matches.is_present("no_wait"),
+        sender_keypair: None,
+        fee_payer: value_t!(matches, "fee_payer", String).ok(),
+        force: false,
+        stake_args: Some(stake_args),
     }
 }
 
@@ -272,7 +284,7 @@ where
             Command::DistributeTokens(parse_distribute_tokens_args(matches))
         }
         ("distribute-stake", Some(matches)) => {
-            Command::DistributeStake(parse_distribute_stake_args(matches))
+            Command::DistributeTokens(parse_distribute_stake_args(matches))
         }
         ("balances", Some(matches)) => Command::Balances(parse_balances_args(matches)),
         ("print-database", Some(matches)) => Command::PrintDb(parse_print_db_args(matches)),

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -124,6 +124,14 @@ where
                         .help("Don't wait for transaction confirmations"),
                 )
                 .arg(
+                    Arg::with_name("sender_keypair")
+                        .long("from")
+                        .takes_value(true)
+                        .value_name("SENDING_KEYPAIR")
+                        .validator(is_valid_signer)
+                        .help("Keypair to fund accounts"),
+                )
+                .arg(
                     Arg::with_name("stake_account_address")
                         .required(true)
                         .long("stake-account-address")
@@ -241,7 +249,7 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs
         dollars_per_sol: None,
         dry_run: matches.is_present("dry_run"),
         no_wait: matches.is_present("no_wait"),
-        sender_keypair: None,
+        sender_keypair: value_t!(matches, "sender_keypair", String).ok(),
         fee_payer: value_t!(matches, "fee_payer", String).ok(),
         force: false,
         stake_args: Some(stake_args),

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -1,6 +1,4 @@
-use crate::args::{
-    Args, BalancesArgs, Command, DistributeStakeArgs, DistributeTokensArgs, PrintDbArgs,
-};
+use crate::args::{Args, BalancesArgs, Command, DistributeTokensArgs, PrintDbArgs, StakeArgs};
 use clap::{value_t, value_t_or_exit, App, Arg, ArgMatches, SubCommand};
 use solana_clap_utils::input_validators::{is_valid_pubkey, is_valid_signer};
 use solana_cli_config::CONFIG_FILE;
@@ -230,16 +228,11 @@ fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArg
 }
 
 fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs<String, String> {
-    let stake_args = DistributeStakeArgs {
-        input_csv: value_t_or_exit!(matches, "input_csv", String),
-        transactions_db: value_t_or_exit!(matches, "transactions_db", String),
-        dry_run: matches.is_present("dry_run"),
-        no_wait: matches.is_present("no_wait"),
+    let stake_args = StakeArgs {
         stake_account_address: value_t_or_exit!(matches, "stake_account_address", String),
         sol_for_fees: value_t_or_exit!(matches, "sol_for_fees", f64),
         stake_authority: value_t!(matches, "stake_authority", String).ok(),
         withdraw_authority: value_t!(matches, "withdraw_authority", String).ok(),
-        fee_payer: value_t!(matches, "fee_payer", String).ok(),
     };
     DistributeTokensArgs {
         input_csv: value_t_or_exit!(matches, "input_csv", String),

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -214,7 +214,7 @@ where
         .get_matches_from(args)
 }
 
-fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs<String> {
+fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs<String, String> {
     DistributeTokensArgs {
         input_csv: value_t_or_exit!(matches, "input_csv", String),
         from_bids: matches.is_present("from_bids"),
@@ -225,6 +225,7 @@ fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArg
         sender_keypair: value_t!(matches, "sender_keypair", String).ok(),
         fee_payer: value_t!(matches, "fee_payer", String).ok(),
         force: matches.is_present("force"),
+        stake_args: None,
     }
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -14,19 +14,14 @@ pub struct DistributeTokensArgs<P, K> {
     pub sender_keypair: Option<K>,
     pub fee_payer: Option<K>,
     pub force: bool,
-    pub stake_args: Option<DistributeStakeArgs<P, K>>,
+    pub stake_args: Option<StakeArgs<P, K>>,
 }
 
-pub struct DistributeStakeArgs<P, K> {
-    pub input_csv: String,
-    pub transactions_db: String,
-    pub dry_run: bool,
-    pub no_wait: bool,
+pub struct StakeArgs<P, K> {
     pub sol_for_fees: f64,
     pub stake_account_address: P,
     pub stake_authority: Option<K>,
     pub withdraw_authority: Option<K>,
-    pub fee_payer: Option<K>,
 }
 
 pub struct BalancesArgs {
@@ -54,14 +49,10 @@ pub struct Args<P, K> {
 
 pub fn resolve_stake_args(
     wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
-    args: DistributeStakeArgs<String, String>,
-) -> Result<DistributeStakeArgs<Pubkey, Box<dyn Signer>>, Box<dyn Error>> {
+    args: StakeArgs<String, String>,
+) -> Result<StakeArgs<Pubkey, Box<dyn Signer>>, Box<dyn Error>> {
     let matches = ArgMatches::default();
-    let resolved_args = DistributeStakeArgs {
-        input_csv: args.input_csv,
-        transactions_db: args.transactions_db,
-        dry_run: args.dry_run,
-        no_wait: args.no_wait,
+    let resolved_args = StakeArgs {
         stake_account_address: pubkey_from_path(
             &matches,
             &args.stake_account_address,
@@ -75,9 +66,6 @@ pub fn resolve_stake_args(
         }),
         withdraw_authority: args.withdraw_authority.as_ref().map(|key_url| {
             signer_from_path(&matches, &key_url, "withdraw authority", wallet_manager).unwrap()
-        }),
-        fee_payer: args.fee_payer.as_ref().map(|key_url| {
-            signer_from_path(&matches, &key_url, "fee-payer", wallet_manager).unwrap()
         }),
     };
     Ok(resolved_args)

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,7 +18,7 @@ pub struct DistributeTokensArgs<P, K> {
 }
 
 pub struct DistributeStakeArgs<P, K> {
-    pub allocations_csv: String,
+    pub input_csv: String,
     pub transactions_db: String,
     pub dry_run: bool,
     pub no_wait: bool,
@@ -59,7 +59,7 @@ pub fn resolve_stake_args(
 ) -> Result<DistributeStakeArgs<Pubkey, Box<dyn Signer>>, Box<dyn Error>> {
     let matches = ArgMatches::default();
     let resolved_args = DistributeStakeArgs {
-        allocations_csv: args.allocations_csv,
+        input_csv: args.input_csv,
         transactions_db: args.transactions_db,
         dry_run: args.dry_run,
         no_wait: args.no_wait,
@@ -91,7 +91,9 @@ pub fn resolve_command(
         Command::DistributeTokens(args) => {
             let mut wallet_manager = maybe_wallet_manager()?;
             let matches = ArgMatches::default();
-            let resolved_stake_args = args.stake_args.map(|args| resolve_stake_args(&mut wallet_manager, args));
+            let resolved_stake_args = args
+                .stake_args
+                .map(|args| resolve_stake_args(&mut wallet_manager, args));
             let resolved_args = DistributeTokensArgs {
                 input_csv: args.input_csv,
                 from_bids: args.from_bids,

--- a/src/args.rs
+++ b/src/args.rs
@@ -42,7 +42,6 @@ pub struct PrintDbArgs {
 
 pub enum Command<P, K> {
     DistributeTokens(DistributeTokensArgs<P, K>),
-    DistributeStake(DistributeStakeArgs<P, K>),
     Balances(BalancesArgs),
     PrintDb(PrintDbArgs),
 }
@@ -111,11 +110,6 @@ pub fn resolve_command(
                 stake_args: resolved_stake_args.map_or(Ok(None), |r| r.map(Some))?,
             };
             Ok(Command::DistributeTokens(resolved_args))
-        }
-        Command::DistributeStake(args) => {
-            let mut wallet_manager = maybe_wallet_manager()?;
-            let resolved_args = resolve_stake_args(&mut wallet_manager, args)?;
-            Ok(Command::DistributeStake(resolved_args))
         }
         Command::Balances(args) => Ok(Command::Balances(args)),
         Command::PrintDb(args) => Ok(Command::PrintDb(args)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,11 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     match resolve_command(command_args.command)? {
         Command::DistributeTokens(args) => {
-            if let Some(args) = args.stake_args {
-                tokens::process_distribute_stake(&thin_client, &args)?;
-            } else {
-                tokens::process_distribute_tokens(&thin_client, &args)?;
-            }
+            tokens::process_distribute_tokens(&thin_client, &args)?;
         }
         Command::Balances(args) => {
             tokens::process_balances(&thin_client, &args)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     match resolve_command(command_args.command)? {
         Command::DistributeTokens(args) => {
-            tokens::process_distribute_tokens(&thin_client, &args)?;
-        }
-        Command::DistributeStake(args) => {
-            tokens::process_distribute_stake(&thin_client, &args)?;
+            if let Some(args) = args.stake_args {
+                tokens::process_distribute_stake(&thin_client, &args)?;
+            } else {
+                tokens::process_distribute_tokens(&thin_client, &args)?;
+            }
         }
         Command::Balances(args) => {
             tokens::process_balances(&thin_client, &args)?;

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -347,13 +347,13 @@ pub fn process_distribute_tokens<T: Client>(
     let starting_total_tokens: f64 = allocations.iter().map(|x| x.amount).sum();
     println!(
         "{} ◎{}",
-        style("Total in allocations_csv:").bold(),
+        style("Total in input_csv:").bold(),
         starting_total_tokens,
     );
     if let Some(dollars_per_sol) = args.dollars_per_sol {
         println!(
             "{} ${}",
-            style("Total in allocations_csv:").bold(),
+            style("Total in input_csv:").bold(),
             starting_total_tokens * dollars_per_sol,
         );
     }
@@ -523,7 +523,7 @@ pub fn process_distribute_stake<T: Client>(
 ) -> Result<Option<usize>, Error> {
     let mut rdr = ReaderBuilder::new()
         .trim(Trim::All)
-        .from_path(&args.allocations_csv)?;
+        .from_path(&args.input_csv)?;
     let allocations: Vec<Allocation> = rdr
         .deserialize()
         .map(|allocation| allocation.unwrap())
@@ -697,9 +697,9 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
         recipient: alice_pubkey.to_string(),
         amount: 1000.0,
     };
-    let allocations_file = NamedTempFile::new().unwrap();
-    let allocations_csv = allocations_file.path().to_str().unwrap().to_string();
-    let mut wtr = csv::WriterBuilder::new().from_writer(allocations_file);
+    let file = NamedTempFile::new().unwrap();
+    let input_csv = file.path().to_str().unwrap().to_string();
+    let mut wtr = csv::WriterBuilder::new().from_writer(file);
     wtr.serialize(&allocation).unwrap();
     wtr.flush().unwrap();
 
@@ -719,7 +719,7 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
         dry_run: false,
         no_wait: false,
         sol_for_fees: 1.0,
-        allocations_csv,
+        input_csv,
         transactions_db: transactions_db.clone(),
     };
     let confirmations = process_distribute_stake(&thin_client, &args).unwrap();

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -108,7 +108,7 @@ fn distribute_tokens<T: Client>(
     client: &ThinClient<T>,
     db: &mut PickleDb,
     allocations: &[Allocation],
-    args: &DistributeTokensArgs<Box<dyn Signer>>,
+    args: &DistributeTokensArgs<Pubkey, Box<dyn Signer>>,
 ) -> Result<(), Error> {
     let signers = if args.dry_run {
         vec![]
@@ -339,7 +339,7 @@ fn read_allocations(
 
 pub fn process_distribute_tokens<T: Client>(
     client: &ThinClient<T>,
-    args: &DistributeTokensArgs<Box<dyn Signer>>,
+    args: &DistributeTokensArgs<Pubkey, Box<dyn Signer>>,
 ) -> Result<Option<usize>, Error> {
     let mut allocations: Vec<Allocation> =
         read_allocations(&args.input_csv, args.from_bids, args.dollars_per_sol);
@@ -617,7 +617,7 @@ pub fn test_process_distribute_tokens_with_client<C: Client>(client: C, sender_k
         .unwrap()
         .to_string();
 
-    let args: DistributeTokensArgs<Box<dyn Signer>> = DistributeTokensArgs {
+    let args: DistributeTokensArgs<Pubkey, Box<dyn Signer>> = DistributeTokensArgs {
         sender_keypair: Some(Box::new(sender_keypair)),
         fee_payer: Some(Box::new(fee_payer)),
         dry_run: false,
@@ -627,6 +627,7 @@ pub fn test_process_distribute_tokens_with_client<C: Client>(client: C, sender_k
         transactions_db: transactions_db.clone(),
         dollars_per_sol: None,
         force: false,
+        stake_args: None,
     };
     let confirmations = process_distribute_tokens(&thin_client, &args).unwrap();
     assert_eq!(confirmations, None);

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -180,6 +180,7 @@ fn distribute_stake<T: Client>(
         } else {
             let signers = vec![
                 &**args.fee_payer.as_ref().unwrap(),
+                &**args.sender_keypair.as_ref().unwrap(),
                 &**stake_args.stake_authority.as_ref().unwrap(),
                 &**stake_args.withdraw_authority.as_ref().unwrap(),
                 &new_stake_account_keypair,
@@ -193,6 +194,7 @@ fn distribute_stake<T: Client>(
         } else {
             let system_sol = stake_args.sol_for_fees;
             let fee_payer_pubkey = args.fee_payer.as_ref().unwrap().pubkey();
+            let sender_pubkey = args.sender_keypair.as_ref().unwrap().pubkey();
             let stake_authority = stake_args.stake_authority.as_ref().unwrap().pubkey();
             let withdraw_authority = stake_args.withdraw_authority.as_ref().unwrap().pubkey();
 
@@ -222,7 +224,7 @@ fn distribute_stake<T: Client>(
             ));
 
             instructions.push(system_instruction::transfer(
-                &fee_payer_pubkey, // Should this be a sender keypair?
+                &sender_pubkey,
                 &recipient,
                 sol_to_lamports(system_sol),
             ));
@@ -648,7 +650,6 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
         .transfer(sol_to_lamports(1.0), &sender_keypair, &fee_payer.pubkey())
         .unwrap();
 
-    // TODO: Create a stake account with lockups
     let stake_account_keypair = Keypair::new();
     let stake_account_address = stake_account_keypair.pubkey();
     let stake_authority = Keypair::new();
@@ -704,7 +705,7 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
         stake_args: Some(stake_args),
         force: false,
         from_bids: false,
-        sender_keypair: None,
+        sender_keypair: Some(Box::new(sender_keypair)),
         dollars_per_sol: None,
     };
     let confirmations = process_distribute_tokens(&thin_client, &args).unwrap();


### PR DESCRIPTION
#### Problem

I implemented the staking functionality by copying all the token functionality. It became a big maintenance burden.

#### Proposed changes

* Unify all that code.
* Make the `--from` argument required when distributed stake - no more using my fee-payer account to create fee-payer accounts for others.
* Ensure signing keys are unique, so that you can use the same `--from` and `--fee-payer` if you'd like and not have to approve twice.