### PR TITLE
Bunch of cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ primary_address,bid_amount_dollars
 ```
 
 ```bash
-solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --input-csv <BIDS_CSV> <TRANSACTION_LOG> --fee-payer <KEYPAIR>
+solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --from-bids --input-csv <BIDS_CSV> --transaction-db <FILE> --fee-payer <KEYPAIR>
 ```
 
 Example transaction log before:
@@ -31,7 +31,7 @@ Send tokens to the recipients in `<BIDS_CSV>` if the distribution is
 not already recordered in the transaction log.
 
 ```bash
-solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --input-csv <BIDS_CSV> <TRANSACTION_LOG> --fee-payer <KEYPAIR>
+solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --from-bids --input-csv <BIDS_CSV> --transaction-db <FILE> --fee-payer <KEYPAIR>
 ```
 
 Example output:
@@ -60,7 +60,7 @@ List the differences between a list of expected distributions and the record of 
 transactions have already been sent.
 
 ```bash
-solana-tokens distribute-tokens --dollars-per-sol <NUMBER> --dry-run --input-csv <BIDS_CSV> <TRANSACTION_LOG>
+solana-tokens distribute-tokens --dollars-per-sol <NUMBER> --dry-run --from-bids --input-csv <BIDS_CSV> --transaction-db <FILE>
 ```
 
 Example bids.csv:
@@ -90,8 +90,8 @@ the new accounts inherit any lockup or custodian settings of the original.
 
 ```bash
 solana-tokens distribute-stake --stake-account-address <ACCOUNT_ADDRESS> \
-    --allocations-csv <ALLOCATIONS_CSV> \
-    <TRANSACTION_LOG> \
+    --input-csv <ALLOCATIONS_CSV> \
+    --transaction-db <FILE> \
     --stake-authority <KEYPAIR> --withdraw-authority <KEYPAIR> --fee-payer <KEYPAIR>
 ```
 

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -69,11 +69,6 @@ where
                         .help("Do not execute any transfers"),
                 )
                 .arg(
-                    Arg::with_name("no_wait")
-                        .long("no-wait")
-                        .help("Don't wait for transaction confirmations"),
-                )
-                .arg(
                     Arg::with_name("sender_keypair")
                         .long("from")
                         .takes_value(true)
@@ -118,11 +113,6 @@ where
                     Arg::with_name("dry_run")
                         .long("dry-run")
                         .help("Do not execute any transfers"),
-                )
-                .arg(
-                    Arg::with_name("no_wait")
-                        .long("no-wait")
-                        .help("Don't wait for transaction confirmations"),
                 )
                 .arg(
                     Arg::with_name("sender_keypair")
@@ -228,7 +218,6 @@ fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArg
         transactions_db: value_t_or_exit!(matches, "transactions_db", String),
         dollars_per_sol: value_t!(matches, "dollars_per_sol", f64).ok(),
         dry_run: matches.is_present("dry_run"),
-        no_wait: matches.is_present("no_wait"),
         sender_keypair: value_t!(matches, "sender_keypair", String).ok(),
         fee_payer: value_t!(matches, "fee_payer", String).ok(),
         force: matches.is_present("force"),
@@ -249,7 +238,6 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs
         transactions_db: value_t_or_exit!(matches, "transactions_db", String),
         dollars_per_sol: None,
         dry_run: matches.is_present("dry_run"),
-        no_wait: matches.is_present("no_wait"),
         sender_keypair: value_t!(matches, "sender_keypair", String).ok(),
         fee_payer: value_t!(matches, "fee_payer", String).ok(),
         force: false,

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -37,8 +37,8 @@ where
                 .about("Distribute tokens")
                 .arg(
                     Arg::with_name("transactions_db")
+                        .long("transactions-db")
                         .required(true)
-                        .index(1)
                         .takes_value(true)
                         .value_name("FILE")
                         .help("Transactions database file"),
@@ -95,8 +95,8 @@ where
                 .about("Distribute stake accounts")
                 .arg(
                     Arg::with_name("transactions_db")
+                        .long("transactions-db")
                         .required(true)
-                        .index(1)
                         .takes_value(true)
                         .value_name("FILE")
                         .help("Transactions database file"),
@@ -193,8 +193,8 @@ where
                 .about("Print the database to a CSV file")
                 .arg(
                     Arg::with_name("transactions_db")
+                        .long("transactions-db")
                         .required(true)
-                        .index(1)
                         .takes_value(true)
                         .value_name("FILE")
                         .help("Transactions database file"),

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -71,6 +71,7 @@ where
                 .arg(
                     Arg::with_name("sender_keypair")
                         .long("from")
+                        .required(true)
                         .takes_value(true)
                         .value_name("SENDING_KEYPAIR")
                         .validator(is_valid_signer)
@@ -79,11 +80,12 @@ where
                 .arg(
                     Arg::with_name("fee_payer")
                         .long("fee-payer")
+                        .required(true)
                         .takes_value(true)
                         .value_name("KEYPAIR")
                         .validator(is_valid_signer)
                         .help("Fee payer"),
-                )
+                ),
         )
         .subcommand(
             SubCommand::with_name("distribute-stake")
@@ -112,6 +114,7 @@ where
                 .arg(
                     Arg::with_name("sender_keypair")
                         .long("from")
+                        .required(true)
                         .takes_value(true)
                         .value_name("SENDING_KEYPAIR")
                         .validator(is_valid_signer)
@@ -137,6 +140,7 @@ where
                 .arg(
                     Arg::with_name("stake_authority")
                         .long("stake-authority")
+                        .required(true)
                         .takes_value(true)
                         .value_name("KEYPAIR")
                         .validator(is_valid_signer)
@@ -145,6 +149,7 @@ where
                 .arg(
                     Arg::with_name("withdraw_authority")
                         .long("withdraw-authority")
+                        .required(true)
                         .takes_value(true)
                         .value_name("KEYPAIR")
                         .validator(is_valid_signer)
@@ -153,6 +158,7 @@ where
                 .arg(
                     Arg::with_name("fee_payer")
                         .long("fee-payer")
+                        .required(true)
                         .takes_value(true)
                         .value_name("KEYPAIR")
                         .validator(is_valid_signer)
@@ -213,8 +219,8 @@ fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArg
         transactions_db: value_t_or_exit!(matches, "transactions_db", String),
         dollars_per_sol: value_t!(matches, "dollars_per_sol", f64).ok(),
         dry_run: matches.is_present("dry_run"),
-        sender_keypair: value_t!(matches, "sender_keypair", String).ok(),
-        fee_payer: value_t!(matches, "fee_payer", String).ok(),
+        sender_keypair: value_t_or_exit!(matches, "sender_keypair", String),
+        fee_payer: value_t_or_exit!(matches, "fee_payer", String),
         stake_args: None,
     }
 }
@@ -223,8 +229,8 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs
     let stake_args = StakeArgs {
         stake_account_address: value_t_or_exit!(matches, "stake_account_address", String),
         sol_for_fees: value_t_or_exit!(matches, "sol_for_fees", f64),
-        stake_authority: value_t!(matches, "stake_authority", String).ok(),
-        withdraw_authority: value_t!(matches, "withdraw_authority", String).ok(),
+        stake_authority: value_t_or_exit!(matches, "stake_authority", String),
+        withdraw_authority: value_t_or_exit!(matches, "withdraw_authority", String),
     };
     DistributeTokensArgs {
         input_csv: value_t_or_exit!(matches, "input_csv", String),
@@ -232,8 +238,8 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs
         transactions_db: value_t_or_exit!(matches, "transactions_db", String),
         dollars_per_sol: None,
         dry_run: matches.is_present("dry_run"),
-        sender_keypair: value_t!(matches, "sender_keypair", String).ok(),
-        fee_payer: value_t!(matches, "fee_payer", String).ok(),
+        sender_keypair: value_t_or_exit!(matches, "sender_keypair", String),
+        fee_payer: value_t_or_exit!(matches, "fee_payer", String),
         stake_args: Some(stake_args),
     }
 }

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -44,13 +44,6 @@ where
                         .help("Transaction database file"),
                 )
                 .arg(
-                    Arg::with_name("transaction_log")
-                        .long("transaction-log")
-                        .takes_value(true)
-                        .value_name("FILE")
-                        .help("Path to transaction log"),
-                )
-                .arg(
                     Arg::with_name("from_bids")
                         .long("from-bids")
                         .help("Input CSV contains bids in dollars, not allocations in SOL"),
@@ -104,13 +97,6 @@ where
                         .takes_value(true)
                         .value_name("FILE")
                         .help("Transaction database file"),
-                )
-                .arg(
-                    Arg::with_name("transaction_log")
-                        .long("transaction-log")
-                        .takes_value(true)
-                        .value_name("FILE")
-                        .help("Path to transaction log"),
                 )
                 .arg(
                     Arg::with_name("input_csv")
@@ -231,7 +217,6 @@ fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArg
         input_csv: value_t_or_exit!(matches, "input_csv", String),
         from_bids: matches.is_present("from_bids"),
         transaction_db: value_t_or_exit!(matches, "transaction_db", String),
-        transaction_log: value_t!(matches, "transaction_log", String).ok(),
         dollars_per_sol: value_t!(matches, "dollars_per_sol", f64).ok(),
         dry_run: matches.is_present("dry_run"),
         sender_keypair: value_t_or_exit!(matches, "sender_keypair", String),
@@ -251,7 +236,6 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs
         input_csv: value_t_or_exit!(matches, "input_csv", String),
         from_bids: false,
         transaction_db: value_t_or_exit!(matches, "transaction_db", String),
-        transaction_log: value_t!(matches, "transaction_log", String).ok(),
         dollars_per_sol: None,
         dry_run: matches.is_present("dry_run"),
         sender_keypair: value_t_or_exit!(matches, "sender_keypair", String),

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -84,11 +84,6 @@ where
                         .validator(is_valid_signer)
                         .help("Fee payer"),
                 )
-                .arg(
-                    Arg::with_name("force")
-                        .long("force")
-                        .help("Do not block transfers is recipients have a non-zero balance"),
-                ),
         )
         .subcommand(
             SubCommand::with_name("distribute-stake")
@@ -220,7 +215,6 @@ fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArg
         dry_run: matches.is_present("dry_run"),
         sender_keypair: value_t!(matches, "sender_keypair", String).ok(),
         fee_payer: value_t!(matches, "fee_payer", String).ok(),
-        force: matches.is_present("force"),
         stake_args: None,
     }
 }
@@ -240,7 +234,6 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs
         dry_run: matches.is_present("dry_run"),
         sender_keypair: value_t!(matches, "sender_keypair", String).ok(),
         fee_payer: value_t!(matches, "fee_payer", String).ok(),
-        force: false,
         stake_args: Some(stake_args),
     }
 }

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -36,12 +36,19 @@ where
             SubCommand::with_name("distribute-tokens")
                 .about("Distribute tokens")
                 .arg(
-                    Arg::with_name("transactions_db")
-                        .long("transactions-db")
+                    Arg::with_name("transaction_db")
+                        .long("transaction-db")
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
-                        .help("Transactions database file"),
+                        .help("Transaction database file"),
+                )
+                .arg(
+                    Arg::with_name("transaction_log")
+                        .long("transaction-log")
+                        .takes_value(true)
+                        .value_name("FILE")
+                        .help("Path to transaction log"),
                 )
                 .arg(
                     Arg::with_name("from_bids")
@@ -91,12 +98,19 @@ where
             SubCommand::with_name("distribute-stake")
                 .about("Distribute stake accounts")
                 .arg(
-                    Arg::with_name("transactions_db")
-                        .long("transactions-db")
+                    Arg::with_name("transaction_db")
+                        .long("transaction-db")
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
-                        .help("Transactions database file"),
+                        .help("Transaction database file"),
+                )
+                .arg(
+                    Arg::with_name("transaction_log")
+                        .long("transaction-log")
+                        .takes_value(true)
+                        .value_name("FILE")
+                        .help("Path to transaction log"),
                 )
                 .arg(
                     Arg::with_name("input_csv")
@@ -193,8 +207,8 @@ where
             SubCommand::with_name("transaction-log")
                 .about("Print the database to a CSV file")
                 .arg(
-                    Arg::with_name("transactions_db")
-                        .long("transactions-db")
+                    Arg::with_name("transaction_db")
+                        .long("transaction-db")
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
@@ -216,7 +230,8 @@ fn parse_distribute_tokens_args(matches: &ArgMatches<'_>) -> DistributeTokensArg
     DistributeTokensArgs {
         input_csv: value_t_or_exit!(matches, "input_csv", String),
         from_bids: matches.is_present("from_bids"),
-        transactions_db: value_t_or_exit!(matches, "transactions_db", String),
+        transaction_db: value_t_or_exit!(matches, "transaction_db", String),
+        transaction_log: value_t!(matches, "transaction_log", String).ok(),
         dollars_per_sol: value_t!(matches, "dollars_per_sol", f64).ok(),
         dry_run: matches.is_present("dry_run"),
         sender_keypair: value_t_or_exit!(matches, "sender_keypair", String),
@@ -235,7 +250,8 @@ fn parse_distribute_stake_args(matches: &ArgMatches<'_>) -> DistributeTokensArgs
     DistributeTokensArgs {
         input_csv: value_t_or_exit!(matches, "input_csv", String),
         from_bids: false,
-        transactions_db: value_t_or_exit!(matches, "transactions_db", String),
+        transaction_db: value_t_or_exit!(matches, "transaction_db", String),
+        transaction_log: value_t!(matches, "transaction_log", String).ok(),
         dollars_per_sol: None,
         dry_run: matches.is_present("dry_run"),
         sender_keypair: value_t_or_exit!(matches, "sender_keypair", String),
@@ -254,7 +270,7 @@ fn parse_balances_args(matches: &ArgMatches<'_>) -> BalancesArgs {
 
 fn parse_transaction_log_args(matches: &ArgMatches<'_>) -> TransactionLogArgs {
     TransactionLogArgs {
-        transactions_db: value_t_or_exit!(matches, "transactions_db", String),
+        transaction_db: value_t_or_exit!(matches, "transaction_db", String),
         output_path: value_t_or_exit!(matches, "output_path", String),
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -7,7 +7,8 @@ use std::{error::Error, sync::Arc};
 pub struct DistributeTokensArgs<P, K> {
     pub input_csv: String,
     pub from_bids: bool,
-    pub transactions_db: String,
+    pub transaction_db: String,
+    pub transaction_log: Option<String>,
     pub dollars_per_sol: Option<f64>,
     pub dry_run: bool,
     pub sender_keypair: K,
@@ -29,7 +30,7 @@ pub struct BalancesArgs {
 }
 
 pub struct TransactionLogArgs {
-    pub transactions_db: String,
+    pub transaction_db: String,
     pub output_path: String,
 }
 
@@ -90,7 +91,8 @@ pub fn resolve_command(
             let resolved_args = DistributeTokensArgs {
                 input_csv: args.input_csv,
                 from_bids: args.from_bids,
-                transactions_db: args.transactions_db,
+                transaction_db: args.transaction_db,
+                transaction_log: args.transaction_log,
                 dollars_per_sol: args.dollars_per_sol,
                 dry_run: args.dry_run,
                 sender_keypair: signer_from_path(

--- a/src/args.rs
+++ b/src/args.rs
@@ -10,16 +10,16 @@ pub struct DistributeTokensArgs<P, K> {
     pub transactions_db: String,
     pub dollars_per_sol: Option<f64>,
     pub dry_run: bool,
-    pub sender_keypair: Option<K>,
-    pub fee_payer: Option<K>,
+    pub sender_keypair: K,
+    pub fee_payer: K,
     pub stake_args: Option<StakeArgs<P, K>>,
 }
 
 pub struct StakeArgs<P, K> {
     pub sol_for_fees: f64,
     pub stake_account_address: P,
-    pub stake_authority: Option<K>,
-    pub withdraw_authority: Option<K>,
+    pub stake_authority: K,
+    pub withdraw_authority: K,
 }
 
 pub struct BalancesArgs {
@@ -59,12 +59,20 @@ pub fn resolve_stake_args(
         )
         .unwrap(),
         sol_for_fees: args.sol_for_fees,
-        stake_authority: args.stake_authority.as_ref().map(|key_url| {
-            signer_from_path(&matches, &key_url, "stake authority", wallet_manager).unwrap()
-        }),
-        withdraw_authority: args.withdraw_authority.as_ref().map(|key_url| {
-            signer_from_path(&matches, &key_url, "withdraw authority", wallet_manager).unwrap()
-        }),
+        stake_authority: signer_from_path(
+            &matches,
+            &args.stake_authority,
+            "stake authority",
+            wallet_manager,
+        )
+        .unwrap(),
+        withdraw_authority: signer_from_path(
+            &matches,
+            &args.withdraw_authority,
+            "withdraw authority",
+            wallet_manager,
+        )
+        .unwrap(),
     };
     Ok(resolved_args)
 }
@@ -85,12 +93,20 @@ pub fn resolve_command(
                 transactions_db: args.transactions_db,
                 dollars_per_sol: args.dollars_per_sol,
                 dry_run: args.dry_run,
-                sender_keypair: args.sender_keypair.as_ref().map(|key_url| {
-                    signer_from_path(&matches, &key_url, "sender", &mut wallet_manager).unwrap()
-                }),
-                fee_payer: args.fee_payer.as_ref().map(|key_url| {
-                    signer_from_path(&matches, &key_url, "fee-payer", &mut wallet_manager).unwrap()
-                }),
+                sender_keypair: signer_from_path(
+                    &matches,
+                    &args.sender_keypair,
+                    "sender",
+                    &mut wallet_manager,
+                )
+                .unwrap(),
+                fee_payer: signer_from_path(
+                    &matches,
+                    &args.fee_payer,
+                    "fee-payer",
+                    &mut wallet_manager,
+                )
+                .unwrap(),
                 stake_args: resolved_stake_args.map_or(Ok(None), |r| r.map(Some))?,
             };
             Ok(Command::DistributeTokens(resolved_args))

--- a/src/args.rs
+++ b/src/args.rs
@@ -12,7 +12,6 @@ pub struct DistributeTokensArgs<P, K> {
     pub dry_run: bool,
     pub sender_keypair: Option<K>,
     pub fee_payer: Option<K>,
-    pub force: bool,
     pub stake_args: Option<StakeArgs<P, K>>,
 }
 
@@ -92,7 +91,6 @@ pub fn resolve_command(
                 fee_payer: args.fee_payer.as_ref().map(|key_url| {
                     signer_from_path(&matches, &key_url, "fee-payer", &mut wallet_manager).unwrap()
                 }),
-                force: args.force,
                 stake_args: resolved_stake_args.map_or(Ok(None), |r| r.map(Some))?,
             };
             Ok(Command::DistributeTokens(resolved_args))

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,7 +8,6 @@ pub struct DistributeTokensArgs<P, K> {
     pub input_csv: String,
     pub from_bids: bool,
     pub transaction_db: String,
-    pub transaction_log: Option<String>,
     pub dollars_per_sol: Option<f64>,
     pub dry_run: bool,
     pub sender_keypair: K,
@@ -92,7 +91,6 @@ pub fn resolve_command(
                 input_csv: args.input_csv,
                 from_bids: args.from_bids,
                 transaction_db: args.transaction_db,
-                transaction_log: args.transaction_log,
                 dollars_per_sol: args.dollars_per_sol,
                 dry_run: args.dry_run,
                 sender_keypair: signer_from_path(

--- a/src/args.rs
+++ b/src/args.rs
@@ -10,7 +10,6 @@ pub struct DistributeTokensArgs<P, K> {
     pub transactions_db: String,
     pub dollars_per_sol: Option<f64>,
     pub dry_run: bool,
-    pub no_wait: bool,
     pub sender_keypair: Option<K>,
     pub fee_payer: Option<K>,
     pub force: bool,
@@ -87,7 +86,6 @@ pub fn resolve_command(
                 transactions_db: args.transactions_db,
                 dollars_per_sol: args.dollars_per_sol,
                 dry_run: args.dry_run,
-                no_wait: args.no_wait,
                 sender_keypair: args.sender_keypair.as_ref().map(|key_url| {
                     signer_from_path(&matches, &key_url, "sender", &mut wallet_manager).unwrap()
                 }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     let config = Config::load(&command_args.config_file)?;
     let json_rpc_url = command_args.url.unwrap_or(config.json_rpc_url);
     let client = RpcClient::new(json_rpc_url);
-    let thin_client = ThinClient::new(client);
 
     match resolve_command(command_args.command)? {
         Command::DistributeTokens(args) => {
+            let thin_client = ThinClient::new(client, args.dry_run);
             tokens::process_distribute_tokens(&thin_client, &args)?;
         }
         Command::Balances(args) => {
+            let thin_client = ThinClient::new(client, false);
             tokens::process_balances(&thin_client, &args)?;
         }
         Command::TransactionLog(args) => {

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -115,28 +115,37 @@ impl Client for BankClient {
     }
 }
 
-pub struct ThinClient<C: Client>(C);
+pub struct ThinClient<C: Client> {
+    client: C,
+    dry_run: bool,
+}
 
 impl<C: Client> ThinClient<C> {
-    pub fn new(client: C) -> Self {
-        Self(client)
+    pub fn new(client: C, dry_run: bool) -> Self {
+        Self { client, dry_run }
     }
 
     pub fn send_transaction(&self, transaction: Transaction) -> Result<Signature> {
-        self.0.send_transaction1(transaction)
+        if self.dry_run {
+            return Ok(Signature::default());
+        }
+        self.client.send_transaction1(transaction)
     }
 
     pub fn get_signature_statuses(
         &self,
         signatures: &[Signature],
     ) -> Result<Vec<Option<TransactionStatus>>> {
-        self.0.get_signature_statuses1(signatures)
+        self.client.get_signature_statuses1(signatures)
     }
 
     pub fn send_and_confirm_transaction(&self, transaction: Transaction) -> Result<Signature> {
+        if self.dry_run {
+            return Ok(Signature::default());
+        }
         // TODO: implement this in terms of ThinClient methods and then remove
         // send_and_confirm_transaction1 from from the Client trait.
-        self.0.send_and_confirm_transaction1(transaction)
+        self.client.send_and_confirm_transaction1(transaction)
     }
 
     pub fn send_message<S: Signers>(&self, message: Message, signers: &S) -> Result<Signature> {
@@ -158,15 +167,15 @@ impl<C: Client> ThinClient<C> {
     }
 
     pub fn get_recent_blockhash(&self) -> Result<(Hash, FeeCalculator)> {
-        self.0.get_recent_blockhash1()
+        self.client.get_recent_blockhash1()
     }
 
     pub fn get_balance(&self, pubkey: &Pubkey) -> Result<u64> {
-        self.0.get_balance1(pubkey)
+        self.client.get_balance1(pubkey)
     }
 
     pub fn get_account(&self, pubkey: &Pubkey) -> Result<Option<Account>> {
-        self.0.get_account1(pubkey)
+        self.client.get_account1(pubkey)
     }
 
     pub fn get_recent_blockhashes(&self) -> Result<Vec<Hash>> {

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -20,7 +20,7 @@ use solana_sdk::{
 use solana_transaction_status::TransactionStatus;
 
 pub trait Client {
-    fn async_send_transaction1(&self, transaction: Transaction) -> Result<Signature>;
+    fn send_transaction1(&self, transaction: Transaction) -> Result<Signature>;
 
     // TODO: Work to delete this
     fn send_and_confirm_transaction1(&self, transaction: Transaction) -> Result<Signature>;
@@ -35,7 +35,7 @@ pub trait Client {
 }
 
 impl Client for RpcClient {
-    fn async_send_transaction1(&self, transaction: Transaction) -> Result<Signature> {
+    fn send_transaction1(&self, transaction: Transaction) -> Result<Signature> {
         self.send_transaction(&transaction)
             .map_err(|e| TransportError::Custom(e.to_string()))
     }
@@ -73,12 +73,12 @@ impl Client for RpcClient {
 }
 
 impl Client for BankClient {
-    fn async_send_transaction1(&self, transaction: Transaction) -> Result<Signature> {
+    fn send_transaction1(&self, transaction: Transaction) -> Result<Signature> {
         self.async_send_transaction(transaction)
     }
 
     fn send_and_confirm_transaction1(&self, transaction: Transaction) -> Result<Signature> {
-        let signature = self.async_send_transaction1(transaction)?;
+        let signature = self.send_transaction1(transaction)?;
         self.poll_for_signature(&signature)?;
         Ok(signature)
     }
@@ -122,8 +122,8 @@ impl<C: Client> ThinClient<C> {
         Self(client)
     }
 
-    pub fn async_send_transaction(&self, transaction: Transaction) -> Result<Signature> {
-        self.0.async_send_transaction1(transaction)
+    pub fn send_transaction(&self, transaction: Transaction) -> Result<Signature> {
+        self.0.send_transaction1(transaction)
     }
 
     pub fn get_signature_statuses(
@@ -133,7 +133,7 @@ impl<C: Client> ThinClient<C> {
         self.0.get_signature_statuses1(signatures)
     }
 
-    pub fn send_transaction(&self, transaction: Transaction) -> Result<Signature> {
+    pub fn send_and_confirm_transaction(&self, transaction: Transaction) -> Result<Signature> {
         // TODO: implement this in terms of ThinClient methods and then remove
         // send_and_confirm_transaction1 from from the Client trait.
         self.0.send_and_confirm_transaction1(transaction)

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -377,11 +377,6 @@ pub fn process_distribute_tokens<T: Client>(
     distribute_tokens(client, &mut db, &allocations, args)?;
 
     let opt_confirmations = finalize_transactions(client, &mut db)?;
-
-    if let Some(transaction_log) = &args.transaction_log {
-        write_transaction_log(&db, transaction_log)?;
-    }
-
     Ok(opt_confirmations)
 }
 
@@ -579,7 +574,6 @@ pub fn test_process_distribute_tokens_with_client<C: Client>(client: C, sender_k
         input_csv,
         from_bids: false,
         transaction_db: transaction_db.clone(),
-        transaction_log: None,
         dollars_per_sol: None,
         stake_args: None,
     };
@@ -675,7 +669,6 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
         dry_run: false,
         input_csv,
         transaction_db: transaction_db.clone(),
-        transaction_log: None,
         stake_args: Some(stake_args),
         from_bids: false,
         sender_keypair: Box::new(sender_keypair),

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -617,8 +617,11 @@ pub fn test_process_distribute_tokens_with_client<C: Client>(client: C, sender_k
 pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_keypair: Keypair) {
     let thin_client = ThinClient::new(client, false);
     let fee_payer = Keypair::new();
-    thin_client
+    let transaction = thin_client
         .transfer(sol_to_lamports(1.0), &sender_keypair, &fee_payer.pubkey())
+        .unwrap();
+    thin_client
+        .poll_for_confirmation(&transaction.signatures[0])
         .unwrap();
 
     let stake_account_keypair = Keypair::new();

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -550,7 +550,7 @@ pub fn process_transaction_log(args: &TransactionLogArgs) -> Result<(), Error> {
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
 use tempfile::{tempdir, NamedTempFile};
 pub fn test_process_distribute_tokens_with_client<C: Client>(client: C, sender_keypair: Keypair) {
-    let thin_client = ThinClient::new(client);
+    let thin_client = ThinClient::new(client, false);
     let fee_payer = Keypair::new();
     thin_client
         .transfer(sol_to_lamports(1.0), &sender_keypair, &fee_payer.pubkey())
@@ -620,7 +620,7 @@ pub fn test_process_distribute_tokens_with_client<C: Client>(client: C, sender_k
 }
 
 pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_keypair: Keypair) {
-    let thin_client = ThinClient::new(client);
+    let thin_client = ThinClient::new(client, false);
     let fee_payer = Keypair::new();
     thin_client
         .transfer(sol_to_lamports(1.0), &sender_keypair, &fee_payer.pubkey())

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -544,8 +544,11 @@ use tempfile::{tempdir, NamedTempFile};
 pub fn test_process_distribute_tokens_with_client<C: Client>(client: C, sender_keypair: Keypair) {
     let thin_client = ThinClient::new(client, false);
     let fee_payer = Keypair::new();
-    thin_client
+    let transaction = thin_client
         .transfer(sol_to_lamports(1.0), &sender_keypair, &fee_payer.pubkey())
+        .unwrap();
+    thin_client
+        .poll_for_confirmation(&transaction.signatures[0])
         .unwrap();
 
     let alice_pubkey = Pubkey::new_rand();


### PR DESCRIPTION
* Remove transaction retries, assume the client implements that (which will be true in the near future)
* Make `--transaction-db` an option, so that in the future it can be optional
* Make all the signer options required
* Remove `--no-wait`, now that the default path is parallelized
* Remove `--force` and the overly cautious check it disables
* Add an optional `--transaction-log` option, so that you can get a CSV-formatted transaction log after dry runs

Fixes #28 #29