### PR TITLE
Sort transaction log by finalized date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,6 +3441,7 @@ dependencies = [
 name = "solana-tokens"
 version = "0.1.1"
 dependencies = [
+ "chrono",
  "clap",
  "console 0.10.3",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,10 @@ license = "Apache-2.0"
 homepage = "https://solana.com/"
 
 [dependencies]
-csv = "1.1.3"
+chrono = { version = "0.4", features = ["serde"] }
 clap = "2.33.0"
 console = "0.10.3"
+csv = "1.1.3"
 indexmap = "1.3.2"
 indicatif = "0.14.0"
 itertools = "0.9.0"


### PR DESCRIPTION
#### Problem

Transaction log would be reordered after each invocation.

#### Proposed Changes

Store the finalized date instead of a Boolean. Sort the log by the date.