### PR TITLE
Make --transaction-db option implicit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,6 +3445,7 @@ dependencies = [
  "clap",
  "console 0.10.3",
  "csv",
+ "dirs",
  "indexmap",
  "indicatif",
  "itertools 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = "2.33.0"
 console = "0.10.3"
 csv = "1.1.3"
+dirs = "2.0.2"
 indexmap = "1.3.2"
 indicatif = "0.14.0"
 itertools = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ primary_address,bid_amount_dollars
 ```
 
 ```bash
-solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --from-bids --input-csv <BIDS_CSV> --transaction-db <FILE> --fee-payer <KEYPAIR>
+solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --from-bids --input-csv <BIDS_CSV> --fee-payer <KEYPAIR>
 ```
 
 Example transaction log before:
@@ -31,7 +31,7 @@ Send tokens to the recipients in `<BIDS_CSV>` if the distribution is
 not already recordered in the transaction log.
 
 ```bash
-solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --from-bids --input-csv <BIDS_CSV> --transaction-db <FILE> --fee-payer <KEYPAIR>
+solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --from-bids --input-csv <BIDS_CSV> --fee-payer <KEYPAIR>
 ```
 
 Example output:
@@ -45,6 +45,10 @@ UKUcTXgbeTYh65RaVV5gSf6xBHevqHvAXMo3e8Q6np8k  43
 
 
 Example transaction log after:
+
+```bash
+solana-tokens transaction-log --output-path transactions.csv
+```
 
 ```text
 recipient,amount,signature
@@ -60,7 +64,7 @@ List the differences between a list of expected distributions and the record of 
 transactions have already been sent.
 
 ```bash
-solana-tokens distribute-tokens --dollars-per-sol <NUMBER> --dry-run --from-bids --input-csv <BIDS_CSV> --transaction-db <FILE>
+solana-tokens distribute-tokens --dollars-per-sol <NUMBER> --dry-run --from-bids --input-csv <BIDS_CSV>
 ```
 
 Example bids.csv:
@@ -91,7 +95,6 @@ the new accounts inherit any lockup or custodian settings of the original.
 ```bash
 solana-tokens distribute-stake --stake-account-address <ACCOUNT_ADDRESS> \
     --input-csv <ALLOCATIONS_CSV> \
-    --transaction-db <FILE> \
     --stake-authority <KEYPAIR> --withdraw-authority <KEYPAIR> --fee-payer <KEYPAIR>
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use solana_cli_config::Config;
+use solana_cli_config::CONFIG_FILE;
 use solana_client::rpc_client::RpcClient;
 use solana_tokens::{
     arg_parser::parse_args,
@@ -8,10 +9,21 @@ use solana_tokens::{
 };
 use std::env;
 use std::error::Error;
+use std::path::Path;
+use std::process;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let command_args = parse_args(env::args_os());
-    let config = Config::load(&command_args.config_file)?;
+    let config = if Path::new(&command_args.config_file).exists() {
+        Config::load(&command_args.config_file)?
+    } else {
+        let default_config_file = CONFIG_FILE.as_ref().unwrap();
+        if command_args.config_file != *default_config_file {
+            eprintln!("Error: config file not found");
+            process::exit(1);
+        }
+        Config::default()
+    };
     let json_rpc_url = command_args.url.unwrap_or(config.json_rpc_url);
     let client = RpcClient::new(json_rpc_url);
 


### PR DESCRIPTION
#### Problem

We currently expose the persistent client state to the user via the --transaction-db option. That can be tucked away in ~/.config/solana-tokens/

#### Proposed Changes

By default, put the database in ~/.config/solana-tokens/transactions.db. Replace the existing required option --transactions-db with a new optional option --campaign-name. Use --campaign-name to keep separate initiatives in separate databases. If provided, use ~/.config/solana-tokens/<NAME>-transactions.db

Also, use the default CLI config if the default config file doesn't exist.

Fixes #32 